### PR TITLE
fix: Set Gin mode based on environment configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,11 @@ func main() {
 	config.Init()
 	cache.Init()
 
-	gin.SetMode(config.ENV)
+	mode := gin.ReleaseMode
+	if config.ENV == "development" {
+		mode = gin.DebugMode
+	}
+	gin.SetMode(mode)
 
 	port := config.PORT
 


### PR DESCRIPTION
Following the instructions in the README, after copying the `.env.example` and running `go run main.go`, I encountered the following error:

```
panic: gin mode unknown: development (available mode: debug release test)

goroutine 1 [running]:
github.com/gin-gonic/gin.SetMode(...)
	/home/enzo/go/pkg/mod/github.com/gin-gonic/gin@v1.10.0/mode.go:74
main.main()
	/home/enzo/Documents/ratoneando-go/main.go:18 +0x23b
exit status 2
```

So I made an adjustment so that if the environment is development, it will be set to debug, otherwise the default will be release.







